### PR TITLE
Ensure all flags have a short variant

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,37 +6,30 @@ and logs, available at
 http://github.com/petervanderdoes/gitflow.
 
 
-Peter van der Does
-Vincent Driessen
-Daniel Dehennin
-Benedikt Böhm
-Leonid Komarovsky
-Felipe Talavera
-Randy Merrill
-Kevin Woo
-Daniel Truemper
-Eric J. Holmes
-Fred Condo
-Alexandre Dutra
-Andreas Heiduk
-Ben Loveridge
-Florian Gamböck
-Gergely Nagy
-JP Toto
-Kiall Mac Innes
-Lorin Hochstein
-Olivier Mengué
-Oppodelldog
-Stefan Näwe
 Adam Gibbins
 Alexander Groß
 Alexander Norström
 Alexander Zeitler
+Alexandre Dutra
+Andreas Heiduk
+Ben Loveridge
+Benedikt Böhm
 Brian St. Pierre
 Cararus Eugeniu
 Chad Walker
 Craig Fowler
+Daniel Dehennin
+Daniel Truemper
+eddie cianci
 Emre Berge Ergenekon
+Eric J. Holmes
+Erik Aigner
+Felipe Talavera
+Florian Gamböck
+Fred Condo
+Gergely Nagy
+gmallard
+gpongelli
 Gregor A. Cieslak
 Gruen Christian-Rolf (Kiki)
 Guillaume-Jean Herbiet
@@ -50,11 +43,16 @@ John Sivak
 Jon Bernard
 Joseph A. Levin
 Joshua P. Tilles
+JP Toto
 Juan Rial
 Justin Penney
+Kevin Woo
+Kiall Mac Innes
 Konstantin Tjuterev
 Kridsada Thanabulpong
 Leonardo Giordani
+Leonid Komarovsky
+Lorin Hochstein
 Luis Fernando Gomes @luiscoms
 Mark Borcherding
 Mark Derricutt
@@ -62,20 +60,23 @@ Mateusz Kaczmarek
 Matias Hernan Lauriti
 Mayerber Carvalho Neto
 Nowell Strite
+Olivier Mengué
 Opher Vishnia
+Oppodelldog
 Peter Schröder
+Peter van der Does
 Pokey Rule
+Randy Merrill
+raybec
+Stefan Näwe
 Stefan Schüßler
 Steffen Jaeckel
 Steve Mao
 Steve Streeting
 Tacit Sawk
 Vedang Manerikar
+Vincent Driessen
 Zheeeng
-eddie cianci
-gmallard
-gpongelli
-raybec
 
 
 Portions of the project are derived from other open source works are clearly

--- a/git-flow
+++ b/git-flow
@@ -119,7 +119,7 @@ main() {
 	. "$GITFLOW_DIR/gitflow-common"
 
 	# allow user to request git action logging
-	DEFINE_boolean 'showcommands' false 'Show actions taken (git commands)'
+	DEFINE_boolean 'showcommands' false 'Show actions taken (git commands)' q
 	# but if the user prefers that the logging is always on,
 	# use the environmental variables.
 	gitflow_override_flag_boolean 'showcommands' 'showcommands'

--- a/git-flow-bugfix
+++ b/git-flow-bugfix
@@ -181,7 +181,7 @@ git flow bugfix start [-h] [-F] <name> [<base>]
 Start new bugfix <name>, optionally basing it on <base> instead of <develop>
 --
 h,help!          Show this help
-showcommands!    Show git commands while executing them
+q,showcommands!  Show git commands while executing them
 F,[no]fetch      Fetch from origin before performing local operation
 "
 	local base
@@ -241,17 +241,18 @@ git flow bugfix finish [-h] [-F] [-r] [-p] [-k] [-D] [-S] [--no-ff] <name|namepr
 Finish bugfix <name>
 --
 h,help!                Show this help
-showcommands!          Show git commands while executing them
+q,showcommands!        Show git commands while executing them
 F,[no]fetch            Fetch from origin before performing finish
 r,[no]rebase           Rebase before merging
 p,[no]preserve-merges  Preserve merges while rebasing
-[no]push               Push to origin after performing finish
+P,[no]push             Push to origin after performing finish
 k,[no]keep             Keep branch after performing finish
-keepremote!        	   Keep the remote branch
-keeplocal!             Keep the local branch
+R,keepremote!          Keep the remote branch
+L,keeplocal!           Keep the local branch
 D,[no]force_delete     Force delete bugfix branch after finish
 S,[no]squash           Squash bugfix during merge
-no-ff!                 Never fast-forward during the merge
+s,[no]squash_info      Add branch info during squash
+m,no-ff!               Never fast-forward during the merge
 "
 	local finish_base
 
@@ -259,14 +260,14 @@ no-ff!                 Never fast-forward during the merge
 	DEFINE_boolean 'fetch' false "fetch from $ORIGIN before performing finish" F
 	DEFINE_boolean 'rebase' false "rebase before merging" r
 	DEFINE_boolean 'preserve-merges' false 'try to recreate merges while rebasing' p
-	DEFINE_boolean 'push' false "push to $ORIGIN after performing finish"
+	DEFINE_boolean 'push' false "push to $ORIGIN after performing finish" P
 	DEFINE_boolean 'keep' false "keep branch after performing finish" k
-	DEFINE_boolean 'keepremote' false "keep the remote branch"
-	DEFINE_boolean 'keeplocal' false "keep the local branch"
+	DEFINE_boolean 'keepremote' false "keep the remote branch" R
+	DEFINE_boolean 'keeplocal' false "keep the local branch" L
 	DEFINE_boolean 'force_delete' false "force delete bugfix branch after finish" D
 	DEFINE_boolean 'squash' false "squash bugfix during merge" S
-	DEFINE_boolean 'squash-info' false "add branch info during squash"
-	DEFINE_boolean 'no-ff!' false "Don't fast-forward ever during merge "
+	DEFINE_boolean 'squash-info' false "add branch info during squash" s
+	DEFINE_boolean 'no-ff!' false "Don't fast-forward ever during merge " m
 
 	# Override defaults with values from config
 	gitflow_override_flag_boolean   "bugfix.finish.fetch"             "fetch"
@@ -507,7 +508,7 @@ Publish bugfix branch <name> on $ORIGIN.
 When <name> is omitted the current branch is used, but only if it's a bugfix branch.
 --
 h,help!          Show this help
-showcommands!    Show git commands while executing them
+q,showcommands!  Show git commands while executing them
 "
 	# Parse arguments
 	parse_args "$@"
@@ -548,7 +549,7 @@ git flow bugfix track [-h] <name>
 Start tracking bugfix <name> that is shared on $ORIGIN
 --
 h,help!          Show this help
-showcommands!    Show git commands while executing them
+q,showcommands!  Show git commands while executing them
 "
 	# Parse arguments
 	parse_args "$@"
@@ -583,7 +584,7 @@ git flow bugfix diff [-h] [<name|nameprefix>]
 Show all changes in <name> that are not in the base
 --
 h,help!          Show this help
-showcommands!    Show git commands while executing them
+q,showcommands!  Show git commands while executing them
 "
 	local base
 
@@ -608,7 +609,7 @@ git flow bugfix checkout [-h] [<name|nameprefix>]
 Switch to bugfix branch <name>
 --
 h,help!          Show this help
-showcommands!    Show git commands while executing them
+q,showcommands!  Show git commands while executing them
 "
 	# Parse arguments
 	parse_args "$@"
@@ -632,7 +633,7 @@ git flow bugfix rebase [-h] [-i] [-p] [<name|nameprefix>]
 Rebase <name> on <base_branch>
 --
 h,help!                Show this help
-showcommands!          Show git commands while executing them
+q,showcommands!        Show git commands while executing them
 i,[no]interactive      Do an interactive rebase
 p,[no]preserve-merges  Preserve merges
 "
@@ -695,7 +696,7 @@ git flow bugfix pull [-h] <remote> [<name>]
 Pull bugfix <name> from <remote>
 --
 h,help!          Show this help
-showcommands!    Show git commands while executing them
+q,showcommands!  Show git commands while executing them
 "
 	local current_branch
 
@@ -764,7 +765,7 @@ git flow bugfix delete [-h] [-f] [-r] <name>
 Delete a given bugfix branch
 --
 h,help!          Show this help
-showcommands!    Show git commands while executing them
+q,showcommands!  Show git commands while executing them
 f,[no]force      Force deletion
 r,[no]remote     Delete remote branch
 "
@@ -836,7 +837,7 @@ git flow bugfix rename <new_name> [<new_name>]
 Rename a given bugfix branch
 --
 h,help!          Show this help
-showcommands!    Show git commands while executing them
+q,showcommands!  Show git commands while executing them
 "
 	gitflow_rename_branch "$@"
 }

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -181,7 +181,7 @@ git flow feature start [-h] [-F] <name> [<base>]
 Start new feature <name>, optionally basing it on <base> instead of <develop>
 --
 h,help!          Show this help
-showcommands!    Show git commands while executing them
+q,showcommands!  Show git commands while executing them
 F,[no]fetch      Fetch from origin before performing local operation
 "
 	local base
@@ -241,17 +241,18 @@ git flow feature finish [-h] [-F] [-r] [-p] [-k] [-D] [-S] [--no-ff] <name|namep
 Finish feature <name>
 --
 h,help!                Show this help
-showcommands!          Show git commands while executing them
+q,showcommands!        Show git commands while executing them
 F,[no]fetch            Fetch from origin before performing finish
 r,[no]rebase           Rebase before merging
 p,[no]preserve-merges  Preserve merges while rebasing
-[no]push               Push to origin after performing finish
+P,[no]push             Push to origin after performing finish
 k,[no]keep             Keep branch after performing finish
-keepremote!        	   Keep the remote branch
-keeplocal!             Keep the local branch
+R,keepremote!          Keep the remote branch
+L,keeplocal!           Keep the local branch
 D,[no]force_delete     Force delete feature branch after finish
 S,[no]squash           Squash feature during merge
-no-ff!                 Never fast-forward during the merge
+s,[no]squash_info      Add branch info during squash
+m,no-ff!               Never fast-forward during the merge
 "
 	local finish_base
 
@@ -259,14 +260,14 @@ no-ff!                 Never fast-forward during the merge
 	DEFINE_boolean 'fetch' false "fetch from $ORIGIN before performing finish" F
 	DEFINE_boolean 'rebase' false "rebase before merging" r
 	DEFINE_boolean 'preserve-merges' false 'try to recreate merges while rebasing' p
-	DEFINE_boolean 'push' false "push to $ORIGIN after performing finish"
+	DEFINE_boolean 'push' false "push to $ORIGIN after performing finish" P
 	DEFINE_boolean 'keep' false "keep branch after performing finish" k
-	DEFINE_boolean 'keepremote' false "keep the remote branch"
-	DEFINE_boolean 'keeplocal' false "keep the local branch"
+	DEFINE_boolean 'keepremote' false "keep the remote branch" R
+	DEFINE_boolean 'keeplocal' false "keep the local branch" L
 	DEFINE_boolean 'force_delete' false "force delete feature branch after finish" D
 	DEFINE_boolean 'squash' false "squash feature during merge" S
-	DEFINE_boolean 'squash-info' false "add branch info during squash"
-	DEFINE_boolean 'no-ff!' false "Don't fast-forward ever during merge "
+	DEFINE_boolean 'squash-info' false "add branch info during squash" s
+	DEFINE_boolean 'no-ff!' false "Don't fast-forward ever during merge " m
 
 	# Override defaults with values from config
 	gitflow_override_flag_boolean   "feature.finish.fetch"             "fetch"
@@ -507,7 +508,7 @@ Publish feature branch <name> on $ORIGIN.
 When <name> is omitted the current branch is used, but only if it's a feature branch.
 --
 h,help!          Show this help
-showcommands!    Show git commands while executing them
+q,showcommands!  Show git commands while executing them
 "
 	# Parse arguments
 	parse_args "$@"
@@ -548,7 +549,7 @@ git flow feature track [-h] <name>
 Start tracking feature <name> that is shared on $ORIGIN
 --
 h,help!          Show this help
-showcommands!    Show git commands while executing them
+q,showcommands!  Show git commands while executing them
 "
 	# Parse arguments
 	parse_args "$@"
@@ -583,7 +584,7 @@ git flow feature diff [-h] [<name|nameprefix>]
 Show all changes in <name> that are not in the base
 --
 h,help!          Show this help
-showcommands!    Show git commands while executing them
+q,showcommands!  Show git commands while executing them
 "
 	local base
 
@@ -608,7 +609,7 @@ git flow feature checkout [-h] [<name|nameprefix>]
 Switch to feature branch <name>
 --
 h,help!          Show this help
-showcommands!    Show git commands while executing them
+q,showcommands!  Show git commands while executing them
 "
 	# Parse arguments
 	parse_args "$@"
@@ -632,7 +633,7 @@ git flow feature rebase [-h] [-i] [-p] [<name|nameprefix>]
 Rebase <name> on <base_branch>
 --
 h,help!                Show this help
-showcommands!          Show git commands while executing them
+q,showcommands!        Show git commands while executing them
 i,[no]interactive      Do an interactive rebase
 p,[no]preserve-merges  Preserve merges
 "
@@ -696,7 +697,7 @@ git flow feature pull [-h] <remote> [<name>]
 Pull feature <name> from <remote>
 --
 h,help!          Show this help
-showcommands!    Show git commands while executing them
+q,showcommands!  Show git commands while executing them
 "
 	local current_branch
 
@@ -765,7 +766,7 @@ git flow feature delete [-h] [-f] [-r] <name>
 Delete a given feature branch
 --
 h,help!          Show this help
-showcommands!    Show git commands while executing them
+q,showcommands!  Show git commands while executing them
 f,[no]force      Force deletion
 r,[no]remote     Delete remote branch
 "
@@ -837,7 +838,7 @@ git flow feature rename <new_name> [<new_name>]
 Rename a given feature branch
 --
 h,help!          Show this help
-showcommands!    Show git commands while executing them
+q,showcommands!  Show git commands while executing them
 "
 	gitflow_rename_branch "$@"
 }

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -170,7 +170,7 @@ git flow hotfix start [-h] [-F] <version> [<base>]
 Start new hotfix branch named <version>, optionally base it on <base> instead of the <master> branch
 --
 h,help!           Show this help
-showcommands!     Show git commands while executing them
+q,showcommands!   Show git commands while executing them
 F,[no]fetch       Fetch from origin before performing local operation
 "
 	local base
@@ -246,7 +246,7 @@ git flow hotfix publish [-h] <version>
 Start sharing hotfix <name> on $ORIGIN
 --
 h,help!           Show this help
-showcommands!     Show git commands while executing them
+q,showcommands!   Show git commands while executing them
 "
 	# Parse arguments
 	parse_args "$@"
@@ -286,7 +286,7 @@ git flow hotfix rebase [-h] [-i] [-p] [<name|nameprefix>]
 Rebase <name> on <base_branch>
 --
 h,help!                Show this help
-showcommands!          Show git commands while executing them
+q,showcommands!        Show git commands while executing them
 i,[no]interactive      Do an interactive rebase
 p,[no]preserve-merges  Preserve merges
 "
@@ -336,7 +336,7 @@ git flow hotfix track [-h] <version>
 Create a tracking hotfix branch from $ORIGIN
 --
 h,help!           Show this help
-showcommands!     Show git commands while executing them
+q,showcommands!   Show git commands while executing them
 "
 	# Parse arguments
 	parse_args "$@"
@@ -366,7 +366,7 @@ git flow hotfix finish [-h] [-F] [-s] [-u] [-m | -f ] [-p] [-k] [-n] [-b] [-S] <
 Finish hotfix branch <version>
 --
 h,help!               Show this help
-showcommands!         Show git commands while executing them
+q,showcommands!       Show git commands while executing them
 F,[no]fetch           Fetch from origin before performing finish
 s,[no]sign            Sign the release tag cryptographically
 u,[no]signingkey      Use the given GPG-key for the digital signature (implies -s)
@@ -374,12 +374,13 @@ m,[no]message         Use the given tag message
 f,[no]messagefile=    Use the contents of the given file as tag message
 p,[no]push            Push to origin after performing finish
 k,[no]keep            Keep branch after performing finish
-[no]keepremote        Keep the remote branch
-[no]keeplocal         Keep the local branch
+R,[no]keepremote      Keep the remote branch
+L,[no]keeplocal       Keep the local branch
 D,[no]force_delete    Force delete hotfix branch after finish
 n,[no]notag           Don't tag this hotfix
 b,[no]nobackmerge     Don't back-merge master, or tag if applicable, in develop
 S,[no]squash          Squash hotfix during merge
+z,[no]squash-info     Add branch info during squash
 T,tagname!            Use given tag name
 "
 	local opts commit keepmsg remotebranchdeleted localbranchdeleted
@@ -392,13 +393,13 @@ T,tagname!            Use given tag name
 	DEFINE_string  'messagefile' "" "use the contents of the given file as tag message" f
 	DEFINE_boolean 'push' false "push to $ORIGIN after performing finish" p
 	DEFINE_boolean 'keep' false "keep branch after performing finish" k
-	DEFINE_boolean 'keepremote' false "keep the remote branch"
-	DEFINE_boolean 'keeplocal' false "keep the local branch"
+	DEFINE_boolean 'keepremote' false "keep the remote branch" R
+	DEFINE_boolean 'keeplocal' false "keep the local branch" L
 	DEFINE_boolean 'force_delete' false "force delete hotfix branch after finish" D
 	DEFINE_boolean 'notag' false "don't tag this hotfix" n
 	DEFINE_boolean 'nobackmerge' false "don't back-merge $MASTER_BRANCH, or tag if applicable, in $DEVELOP_BRANCH " b
 	DEFINE_boolean 'squash' false "squash release during merge" S
-	DEFINE_boolean 'squash-info' false "add branch info during squash"
+	DEFINE_boolean 'squash-info' false "add branch info during squash" z
 	DEFINE_string  'tagname' "" "use the given tag name" T
 
 	# Override defaults with values from config
@@ -672,7 +673,7 @@ git flow hotfix delete [-h] [-f] [-r] <name>
 Delete the given hotfix branch
 --
 h,help!               Show this help
-showcommands!         Show git commands while executing them
+q,showcommands!       Show git commands while executing them
 f,[no]force           Force deletion
 r,[no]remote          Delete remote branch
 "
@@ -737,7 +738,7 @@ git flow hotfix rename <new_name> [<new_name>]
 Rename a given hotfix branch
 --
 h,help!          Show this help
-showcommands!    Show git commands while executing them
+q,showcommands!  Show git commands while executing them
 "
 	gitflow_rename_branch "$@"
 }

--- a/git-flow-init
+++ b/git-flow-init
@@ -63,7 +63,7 @@ git flow init [-h] [-d] [-f]
 Setup a git repository for git flow usage. Can also be used to start a git repository.
 --
 h,help!             Show this help
-showcommands!       Show git commands while executing them
+q,showcommands!     Show git commands while executing them
 d,[no]defaults      Use default branch naming conventions
 f,[no]force         Force setting of gitflow branches, even if already configured
 
@@ -75,10 +75,10 @@ s,support!          Support branches
 t,tag!              Version tag prefix
 
 Use config file location
-local!   use repository config file
-global!  use global config file
-system!  use system config file
-file=    use given config file
+L,local!   use repository config file
+G,global!  use global config file
+S,system!  use system config file
+F,file=    use given config file
 "
 	local gitflow_config_option should_check_existence branchcount guess
 	local master_branch develop_branch default_suggestion answer prefix
@@ -86,10 +86,10 @@ file=    use given config file
 	# Define flags
 	DEFINE_boolean 'force' false 'force setting of gitflow branches, even if already configured' f
 	DEFINE_boolean 'defaults' false 'use default branch naming conventions' d
-	DEFINE_boolean 'local' false 'use repository config file'
-	DEFINE_boolean 'global' false 'use global config file'
-	DEFINE_boolean 'system' false 'use system config file'
-	DEFINE_string 'file' "" 'use given config file'
+	DEFINE_boolean 'local' false 'use repository config file' L
+	DEFINE_boolean 'global' false 'use global config file' G
+	DEFINE_boolean 'system' false 'use system config file' S
+	DEFINE_string 'file' "" 'use given config file' F
 	DEFINE_string 'feature' "" 'feature branches' p
 	DEFINE_string 'bugfix' "" 'bugfix branches' b
 	DEFINE_string 'release' "" 'release branches' r

--- a/git-flow-log
+++ b/git-flow-log
@@ -72,8 +72,8 @@ git flow feature log [<options>]
 Show log on <feature> branch since the fork of <develop> branch
 Options come from git log
 --
-h,help!         Show this help
-showcommands!   Show git commands while executing them
+h,help!             Show this help
+q,showcommands!     Show git commands while executing them
 "
 
 	# Parse arguments

--- a/git-flow-release
+++ b/git-flow-release
@@ -553,7 +553,7 @@ git flow release start [options] <version> [<base>]
 Start a new release branch
 --
 h,help!              Show this help
-showcommands!        Show git commands while executing them
+q,showcommands!      Show git commands while executing them
 F,[no]fetch          Fetch from $ORIGIN before performing finish
 v,verbose!           Verbose (more) output
 "
@@ -625,28 +625,29 @@ git flow release finish [-h] [-F] [-s] [-u] [-m | -f] [-p] [-k] [-n] [-b] [-S] [
 
 Finish a release branch
 --
-h,help              Show this help
-showcommands!       Show git commands while executing them
-F,[no]fetch         Fetch from origin before performing finish
-s,sign!             Sign the release tag cryptographically
-u,signingkey!       Use the given GPG-key for the digital signature (implies -s)
-m,message!          Use the given tag message
-f,[no]messagefile=  Use the contents of the given file as a tag message
-p,[no]push          Push to origin after performing finish
-[no]pushproduction  Push the production branch
-[no]pushdevelop     Push the develop branch
-[no]pushtag         Push the tag
-k,[no]keep          Keep branch after performing finish
-[no]keepremote      Keep the remote branch
-[no]keeplocal       Keep the local branch
-D,[no]force_delete  Force delete release branch after finish
-n,[no]tag           Don't tag this release
-b,[no]nobackmerge   Don't back-merge master, or tag if applicable, in develop
-S,[no]squash        Squash release during merge
-[no]ff-master       Fast forward master branch if possible
-e,[no]edit          The --noedit option can be used to accept the auto-generated message on merging
-T,tagname!          Use given tag name
-nodevelopmerge!  Don't back-merge develop branch
+h,help                  Show this help
+q,showcommands!         Show git commands while executing them
+F,[no]fetch             Fetch from origin before performing finish
+s,sign!                 Sign the release tag cryptographically
+u,signingkey!           Use the given GPG-key for the digital signature (implies -s)
+m,message!              Use the given tag message
+f,[no]messagefile=      Use the contents of the given file as a tag message
+p,[no]push              Push to origin after performing finish
+P,[no]pushproduction    Push the production branch
+d,[no]pushdevelop       Push the develop branch
+t,[no]pushtag           Push the tag
+k,[no]keep              Keep branch after performing finish
+R,[no]keepremote        Keep the remote branch
+L,[no]keeplocal         Keep the local branch
+D,[no]force_delete      Force delete release branch after finish
+n,[no]tag               Don't tag this release
+b,[no]nobackmerge       Don't back-merge master, or tag if applicable, in develop
+S,[no]squash            Squash release during merge
+i,[no]squash-info       Add branch info during squash
+z,[no]ff-master         Fast forward master branch if possible
+e,[no]edit              The --noedit option can be used to accept the auto-generated message on merging
+T,tagname!              Use given tag name
+M,nodevelopmerge!       Don't back-merge develop branch
 "
 	# Define flags
 	DEFINE_boolean 'fetch' false "fetch from $ORIGIN before performing finish" F
@@ -655,21 +656,21 @@ nodevelopmerge!  Don't back-merge develop branch
 	DEFINE_string  'message' "" "use the given tag message" m
 	DEFINE_string  'messagefile' "" "use the contents of the given file as a tag message" f
 	DEFINE_boolean 'push' false "push to $ORIGIN after performing finish" p
-	DEFINE_boolean 'pushproduction' false "push the production branch"
-	DEFINE_boolean 'pushdevelop' false "push the develop branch"
-	DEFINE_boolean 'pushtag' false "push the tag"
+	DEFINE_boolean 'pushproduction' false "push the production branch" P
+	DEFINE_boolean 'pushdevelop' false "push the develop branch" d
+	DEFINE_boolean 'pushtag' false "push the tag" t
 	DEFINE_boolean 'keep' false "keep branch after performing finish" k
-	DEFINE_boolean 'keepremote' false "keep the remote branch"
-	DEFINE_boolean 'keeplocal' false "keep the local branch"
+	DEFINE_boolean 'keepremote' false "keep the remote branch" R
+	DEFINE_boolean 'keeplocal' false "keep the local branch" L
 	DEFINE_boolean 'force_delete' false "force delete release branch after finish" D
 	DEFINE_boolean 'notag' false "don't tag this release" n
 	DEFINE_boolean 'nobackmerge' false "don't back-merge $MASTER_BRANCH, or tag if applicable, in $DEVELOP_BRANCH " b
 	DEFINE_boolean 'squash' false "squash release during merge" S
-	DEFINE_boolean 'squash-info' false "add branch info during squash"
-	DEFINE_boolean 'ff-master' false "fast forward master branch if possible"
+	DEFINE_boolean 'squash-info' false "add branch info during squash" i
+	DEFINE_boolean 'ff-master' false "fast forward master branch if possible" z
 	DEFINE_boolean 'edit' true "accept the auto-generated message on merging" e
 	DEFINE_string  'tagname' "" "use the given tag name" T
-	DEFINE_boolean 'nodevelopmerge' false "don't merge $BRANCH into $DEVELOP_BRANCH "
+	DEFINE_boolean 'nodevelopmerge' false "don't merge $BRANCH into $DEVELOP_BRANCH " M
 
 	# Override defaults with values from config
 	gitflow_override_flag_boolean   "release.finish.fetch"          "fetch"
@@ -768,15 +769,15 @@ git flow release branch [-h] [-F] [-s] [-u] [-m] [-f] [-p] [-n] [-S] <version> [
 Release a branch [<name>], if a name is not given it defaults to the develop branch, and use the given version <version>
 --
 h,help              Show this help
-showcommands!       Show git commands while executing them
-F,[no]fetch 		Fetch from origin before performing finish
+q,showcommands!     Show git commands while executing them
+F,[no]fetch         Fetch from origin before performing finish
 s,sign!             Sign the release tag cryptographically
-u,signingkey!    	Use the given GPG-key for the digital signature (implies -s)
-m,message! 	    	Use the given tag message
-f,[no]messagefile= 	Use the contents of the given file as a tag message
-p,[no]push 			Push to origin after performing finish
-n,[no]tag 			Don't tag this release
-S,[no]squash 		Squash release during merge
+u,signingkey!       Use the given GPG-key for the digital signature (implies -s)
+m,message! 	        Use the given tag message
+f,[no]messagefile=  Use the contents of the given file as a tag message
+p,[no]push          Push to origin after performing finish
+n,[no]tag           Don't tag this release
+S,[no]squash        Squash release during merge
 "
 	local opts
 
@@ -924,8 +925,8 @@ git flow release publish [-h] <name>
 
 Publish the release branch <name> on $ORIGIN
 --
-h,help           Show this help
-showcommands!    Show git commands while executing them
+h,help              Show this help
+q,showcommands!     Show git commands while executing them
 "
 	# Parse arguments
 	parse_args "$@"
@@ -964,8 +965,8 @@ git flow release track [-h] <name>
 
 Start tracking release <name> that is shared on $ORIGIN
 --
-h,help           Show this help
-showcommands!    Show git commands while executing them
+h,help              Show this help
+q,showcommands!     Show git commands while executing them
 "
 	# Parse arguments
 	parse_args "$@"
@@ -1000,7 +1001,7 @@ git flow release rebase [-h] [-i] [-p] [<name|nameprefix>]
 Rebase <name> on <base_branch>
 --
 h,help!                Show this help
-showcommands!          Show git commands while executing them
+q,showcommands!        Show git commands while executing them
 i,[no]interactive      Do an interactive rebase
 p,[no]preserve-merges  Preserve merges
 "
@@ -1050,7 +1051,7 @@ git flow release delete [-h] [-f] [-r] <name>
 Delete the given release branch
 --
 h,help           Show this help
-showcommands!    Show git commands while executing them
+q,showcommands!  Show git commands while executing them
 f,[no]force      Force deletion
 r,[no]remote     Delete remote branch
 "

--- a/git-flow-support
+++ b/git-flow-support
@@ -163,7 +163,7 @@ git flow support start [-h] [-F] <version> <base>
 Start a new support branch name <version> based on <base>
 --
 h,help!           Show this help
-showcommands!     Show git commands while executing them
+q,showcommands!   Show git commands while executing them
 F,[no]fetch       Fetch from origin before performing finish
 "
 	# Define flags
@@ -207,7 +207,7 @@ git flow support rebase [-h] [-i] [-p] [<name|nameprefix>]
 Rebase <name> on <base_branch>
 --
 h,help!                Show this help
-showcommands!          Show git commands while executing them
+q,showcommands!        Show git commands while executing them
 i,[no]interactive      Do an interactive rebase
 p,[no]preserve-merges  Preserve merges
 "


### PR DESCRIPTION
This is a re submission of [PR 462](https://github.com/petervanderdoes/gitflow-avh/pull/462#issue-934722615) in reference to [issue 461](https://github.com/petervanderdoes/gitflow-avh/issues/461#issue-934626645)

macOS/BSD getopt does not allow for long flag variants without installing gnu-getopt. This makes it hard to bundle git-flow with applications, since you usually can't bundle gnu-getopt with them. To address this, a short variant has been added for each command.