### PR TITLE
<fix>(git-flow-log): fixed help message

### DIFF
--- a/git-flow-log
+++ b/git-flow-log
@@ -48,7 +48,7 @@ usage() {
 	OPTIONS_SPEC="\
 git flow log
 
-shows current branch log compared to develop
+shows current branch log compared to base branch
 'git help log' for arguments
 --
 "
@@ -69,7 +69,7 @@ cmd_list() {
 	OPTIONS_SPEC="\
 git flow feature log [<options>]
 
-Show log on <feature> branch since the fork of <develop> branch
+Show log on current branch since the fork of base branch
 Options come from git log
 --
 h,help!         Show this help


### PR DESCRIPTION
This is a re submission of [PR 460](https://github.com/petervanderdoes/gitflow-avh/pull/460#issue-931004688)

"git flow log" works not only for feature branches