### PR TITLE
Allowed a release branch to be renamed

### DIFF
--- a/git-flow-release
+++ b/git-flow-release
@@ -420,6 +420,7 @@ git flow release finish
 git flow release publish
 git flow release track
 git flow release delete
+git flow release rename
 
 Manage your release branches.
 
@@ -1094,4 +1095,16 @@ r,[no]remote     Delete remote branch
 	flag remote && echo "- Release branch '$BRANCH' in '$ORIGIN' has been deleted."
 	echo "- You are now on branch '$(git_current_branch)'"
 	echo
+}
+
+cmd_rename() {
+	OPTIONS_SPEC="\
+git flow release rename <new_name> [<new_name>]
+
+Rename a given release branch
+--
+h,help!          Show this help
+showcommands!    Show git commands while executing them
+"
+	gitflow_rename_branch "$@"
 }


### PR DESCRIPTION
This is a re submission of [PR 392](https://github.com/petervanderdoes/gitflow-avh/pull/392#issue-378011774)

This is useful for situations in which there is an active release branch but then a hotfix is required that will require the release branch to bump the version.

For example, if `release/1.2.1` exists but then `hotfix/1.2.1` happens, the release branch now needs renaming to `release/1.2.2`.