### PR TITLE
fix(release): fix typo in ff-master option, should use underscore

### DIFF
--- a/git-flow-release
+++ b/git-flow-release
@@ -667,7 +667,7 @@ nodevelopmerge!  Don't back-merge develop branch
 	gitflow_override_flag_boolean   "release.finish.nobackmerge"    "nobackmerge"
 	gitflow_override_flag_boolean   "release.finish.squash"         "squash"
 	gitflow_override_flag_boolean   "release.finish.squash-info"    "squash_info"
-	gitflow_override_flag_boolean   "release.finish.ff-master"      "ff-master"
+	gitflow_override_flag_boolean   "release.finish.ff-master"      "ff_master"
 	gitflow_override_flag_string    "release.finish.signingkey"     "signingkey"
 	gitflow_override_flag_string    "release.finish.message"        "message"
 	gitflow_override_flag_string    "release.finish.messagefile"    "messagefile"


### PR DESCRIPTION
This is a re submission of [PR 379](https://github.com/petervanderdoes/gitflow-avh/pull/379#issue-349366122)