### PR TITLE
Allow gitflow.feature.finish.no-ff to be configured during gt flow init.

### DIFF
--- a/git-flow-init
+++ b/git-flow-init
@@ -374,6 +374,19 @@ file=    use given config file
 		git_do config $gitflow_config_option gitflow.path.hooks "$hooks_dir"
 	fi
 
+	# no-ff setting
+	if ! git config --get gitflow.feature.finish.no-ff >/dev/null 2>&1 || flag force; then
+		default_suggestion=$(git config --get gitflow.feature.finish.no-ff || echo "true")
+		printf "Do not fast forward when finishing? [$default_suggestion] "
+		if noflag defaults; then
+			read answer
+		else
+			printf "\n"
+		fi
+		[ "$answer" = "-" ] && no_ff= || no_ff=${answer:-$default_suggestion}
+		git_do config $gitflow_config_option gitflow.feature.finish.no-ff "$no_ff"
+	fi
+
 	# TODO: what to do with origin?
 }
 


### PR DESCRIPTION
This is a re submission of [PR 292](https://github.com/petervanderdoes/gitflow-avh/pull/292#issue-180967574) in reference to [issue 291](https://github.com/petervanderdoes/gitflow-avh/issues/291#issue-180898641)