### PR TITLE
feat:  Add option to sign the initial commit on production branch when creating a new repository with git flow init

### DIFF
--- a/git-flow
+++ b/git-flow
@@ -7,7 +7,7 @@
 #    http://blog.avirtualhome.com/development-workflow-using-git/
 #
 # Feel free to contribute to this project at:
-#    http://github.com/petervanderdoes/gitflow
+#    http://github.com/CJ-Systems/gitflow-cjs
 #
 # Authors:
 # Copyright 2003 CJ Systems. All rights reserved.

--- a/git-flow
+++ b/git-flow
@@ -10,6 +10,7 @@
 #    http://github.com/petervanderdoes/gitflow
 #
 # Authors:
+# Copyright 2003 CJ Systems. All rights reserved.
 # Copyright 2012-2019 Peter van der Does. All rights reserved.
 #
 # Original Author:

--- a/git-flow-bugfix
+++ b/git-flow-bugfix
@@ -8,7 +8,7 @@
 #    http://blog.avirtualhome.com/development-workflow-using-git/
 #
 # Feel free to contribute to this project at:
-#    http://github.com/petervanderdoes/gitflow
+#    http://github.com/CJ-Systems/gitflow-cjs
 #
 # Authors:
 # Copyright 2003 CJ Systems. All rights reserved.

--- a/git-flow-bugfix
+++ b/git-flow-bugfix
@@ -11,6 +11,7 @@
 #    http://github.com/petervanderdoes/gitflow
 #
 # Authors:
+# Copyright 2003 CJ Systems. All rights reserved.
 # Copyright 2012-2019 Peter van der Does. All rights reserved.
 #
 # Original Author:

--- a/git-flow-config
+++ b/git-flow-config
@@ -8,7 +8,7 @@
 #    http://blog.avirtualhome.com/development-workflow-using-git/
 #
 # Feel free to contribute to this project at:
-#    http://github.com/petervanderdoes/gitflow
+#    http://github.com/CJ-Systems/gitflow-cjs
 #
 # Authors:
 # Copyright 2003 CJ Systems. All rights reserved.

--- a/git-flow-config
+++ b/git-flow-config
@@ -11,6 +11,7 @@
 #    http://github.com/petervanderdoes/gitflow
 #
 # Authors:
+# Copyright 2003 CJ Systems. All rights reserved.
 # Copyright 2012-2019 Peter van der Does. All rights reserved.
 #
 #

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -8,7 +8,7 @@
 #    http://blog.avirtualhome.com/development-workflow-using-git/
 #
 # Feel free to contribute to this project at:
-#    http://github.com/petervanderdoes/gitflow
+#    http://github.com/CJ-Systems/gitflow-cjs
 #
 # Authors:
 # Copyright 2003 CJ Systems. All rights reserved.

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -11,6 +11,7 @@
 #    http://github.com/petervanderdoes/gitflow
 #
 # Authors:
+# Copyright 2003 CJ Systems. All rights reserved.
 # Copyright 2012-2019 Peter van der Does. All rights reserved.
 #
 # Original Author:

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -8,7 +8,7 @@
 #    http://blog.avirtualhome.com/development-workflow-using-git/
 #
 # Feel free to contribute to this project at:
-#    http://github.com/petervanderdoes/gitflow
+#    http://github.com/CJ-Systems/gitflow-cjs
 #
 # Authors:
 # Copyright 2003 CJ Systems. All rights reserved.

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -11,6 +11,7 @@
 #    http://github.com/petervanderdoes/gitflow
 #
 # Authors:
+# Copyright 2003 CJ Systems. All rights reserved.
 # Copyright 2012-2019 Peter van der Does. All rights reserved.
 #
 # Original Author:

--- a/git-flow-init
+++ b/git-flow-init
@@ -8,7 +8,7 @@
 #    http://blog.avirtualhome.com/development-workflow-using-git/
 #
 # Feel free to contribute to this project at:
-#    http://github.com/petervanderdoes/gitflow
+#    http://github.com/CJ-Systems/gitflow-cjs
 #
 # Authors:
 # Copyright 2003 CJ Systems. All rights reserved.

--- a/git-flow-init
+++ b/git-flow-init
@@ -11,6 +11,7 @@
 #    http://github.com/petervanderdoes/gitflow
 #
 # Authors:
+# Copyright 2003 CJ Systems. All rights reserved.
 # Copyright 2012-2019 Peter van der Does. All rights reserved.
 #
 # Original Author:

--- a/git-flow-init
+++ b/git-flow-init
@@ -67,6 +67,7 @@ h,help!             Show this help
 showcommands!       Show git commands while executing them
 d,[no]defaults      Use default branch naming conventions
 f,[no]force         Force setting of gitflow branches, even if already configured
+g,[no]sign			Sign initial commit when creating a repository
 
 p,feature!          Feature branches
 b,bugfix!           Bugfix branches
@@ -90,6 +91,7 @@ file=    use given config file
 	DEFINE_boolean 'local' false 'use repository config file'
 	DEFINE_boolean 'global' false 'use global config file'
 	DEFINE_boolean 'system' false 'use system config file'
+	DEFINE_boolean 'sign' false 'sign initial commit when creating a repository' g
 	DEFINE_string 'file' "" 'use given config file'
 	DEFINE_string 'feature' "" 'feature branches' p
 	DEFINE_string 'bugfix' "" 'bugfix branches' b
@@ -260,8 +262,13 @@ file=    use given config file
 	local created_gitflow_branch=0
 	if ! git rev-parse --quiet --verify HEAD >/dev/null 2>&1; then
 		git_do symbolic-ref HEAD "refs/heads/$master_branch"
-		git_do commit --allow-empty --quiet -m "Initial commit"
-		created_gitflow_branch=1
+		if flag sign; then
+			git_do commit --allow-empty --gpg-sign --quiet -m "initial commit"
+			created_gitflow_branch=1
+		else
+			git_do commit --allow-empty --quiet -m "initial commit"
+			created_gitflow_branch=1
+		fi
 	fi
 
 	# Creation of master

--- a/git-flow-log
+++ b/git-flow-log
@@ -8,7 +8,7 @@
 #    http://blog.avirtualhome.com/development-workflow-using-git/
 #
 # Feel free to contribute to this project at:
-#    http://github.com/petervanderdoes/gitflow
+#    http://github.com/CJ-Systems/gitflow-cjs
 #
 # Authors:
 # Copyright 2003 CJ Systems. All rights reserved.

--- a/git-flow-log
+++ b/git-flow-log
@@ -11,6 +11,7 @@
 #    http://github.com/petervanderdoes/gitflow
 #
 # Authors:
+# Copyright 2003 CJ Systems. All rights reserved.
 # Copyright 2012-2019 Peter van der Does. All rights reserved.
 #
 # Original Author:

--- a/git-flow-release
+++ b/git-flow-release
@@ -8,7 +8,7 @@
 #    http://blog.avirtualhome.com/development-workflow-using-git/
 #
 # Feel free to contribute to this project at:
-#    http://github.com/petervanderdoes/gitflow
+#    http://github.com/CJ-Systems/gitflow-cjs
 #
 # Authors:
 # Copyright 2003 CJ Systems. All rights reserved.

--- a/git-flow-release
+++ b/git-flow-release
@@ -11,6 +11,7 @@
 #    http://github.com/petervanderdoes/gitflow
 #
 # Authors:
+# Copyright 2003 CJ Systems. All rights reserved.
 # Copyright 2012-2019 Peter van der Does. All rights reserved.
 #
 # Original Author:

--- a/git-flow-support
+++ b/git-flow-support
@@ -8,7 +8,7 @@
 #    http://blog.avirtualhome.com/development-workflow-using-git/
 #
 # Feel free to contribute to this project at:
-#    http://github.com/petervanderdoes/gitflow
+#    http://github.com/CJ-Systems/gitflow-cjs
 #
 # Authors:
 # Copyright 2003 CJ Systems. All rights reserved.

--- a/git-flow-support
+++ b/git-flow-support
@@ -11,6 +11,7 @@
 #    http://github.com/petervanderdoes/gitflow
 #
 # Authors:
+# Copyright 2003 CJ Systems. All rights reserved.
 # Copyright 2012-2019 Peter van der Does. All rights reserved.
 #
 # Original Author:

--- a/git-flow-version
+++ b/git-flow-version
@@ -8,7 +8,7 @@
 #    http://blog.avirtualhome.com/development-workflow-using-git/
 #
 # Feel free to contribute to this project at:
-#    http://github.com/petervanderdoes/gitflow
+#    http://github.com/CJ-Systems/gitflow-cjs
 #
 # Authors:
 # Copyright 2003 CJ Systems. All rights reserved.

--- a/git-flow-version
+++ b/git-flow-version
@@ -11,6 +11,7 @@
 #    http://github.com/petervanderdoes/gitflow
 #
 # Authors:
+# Copyright 2003 CJ Systems. All rights reserved.
 # Copyright 2012-2019 Peter van der Does. All rights reserved.
 #
 # Original Author:

--- a/gitflow-common
+++ b/gitflow-common
@@ -8,7 +8,7 @@
 #    http://blog.avirtualhome.com/development-workflow-using-git/
 #
 # Feel free to contribute to this project at:
-#    http://github.com/petervanderdoes/gitflow
+#    http://github.com/CJ-Systems/gitflow-cjs
 #
 # Authors:
 # Copyright 2003 CJ Systems. All rights reserved.

--- a/gitflow-common
+++ b/gitflow-common
@@ -11,6 +11,7 @@
 #    http://github.com/petervanderdoes/gitflow
 #
 # Authors:
+# Copyright 2003 CJ Systems. All rights reserved.
 # Copyright 2012-2019 Peter van der Does. All rights reserved.
 #
 # Original Author:


### PR DESCRIPTION
The -g, --sign flag will create a gpg-signed commit when creating the production branch in a new git repository. This will allow for the option to use the Require Signed Commits branch protection rule on GitHub.
 
closes #59
