### PR TITLE
feat(hotfix): add  backmerge option to release branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 #### 2.2.0-SNAPSHOT
+* feat: add option to hotfix finish to allow for backmerge to release branch. Thank You [Bankers88](https://github.com/Bankers88)
+* fix: Prevent hotfixes being merged to develop with nobackmerge flag. Thank You [adamrodger](https://github.com/adamrodger)
 * feat(feature): add release sub command. Thank You [codesurf42](https://github.com/codesurf42) for the initial pr
 * feat(init): add sign flag to create initial signed commit
 * feat(init): add support for "Support Git Environment Credentials" pull request #19 from filipekiss/feature/environment_credentials
@@ -9,14 +11,12 @@
 * fix: wording for help text in git flow log pull request #15 from Shea690901/hotfix/git-flow-log_help-message
 * refactor(git-flow): add support for busybox-readlink request #12 from KAction/readlink-busybox
 
-
 #### 2.1.0
 * feat: add create command to release allowing for a single step release prodution
 * feat: add missing hook script filter-flow-release-finish-version
 * fix: multi-line tag message when using -m
 * docs: update readme with better description as to why this fork was created. Thank You [shaedrick](https://github.com/shaedrich)
 **NOTE:** The format for a multi-line tag message is now "$(printf 'line of text with \n escape codes placed as needed for proper formating of the message')"
-
 
 #### 2.0.1
 * fix incorrect version identification along with updating source repository in gitflow-installer. Corrections pointed out by [bobstuart](https://github.com/bobstuart)

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -552,35 +552,22 @@ T,tagname!            Use given tag name
 		fi
 	fi
 
-	if [ "$BASE_BRANCH" = "$MASTER_BRANCH" ]; then
-		# By default we back-merge the $MASTER_BRANCH unless the user explicitly
-		# stated not to do a back-merge, in that case we use the $BRANCH.
-		if noflag nobackmerge; then
-			MERGE_BRANCH="$BASE_BRANCH"
-		else
-			MERGE_BRANCH="$BRANCH"
-		fi
-
-		# Try to merge into develop.
+	if [ "$BASE_BRANCH" = "$MASTER_BRANCH" ] && noflag nobackmerge; then
+		# Try to merge into develop unless the user specified the nobackmerge option.
 		# In case a previous attempt to finish this release branch has failed,
 		# but the merge into develop was successful, we skip it now
-		if ! git_is_branch_merged_into "$MERGE_BRANCH" "$DEVELOP_BRANCH"; then
-			git_do checkout "$DEVELOP_BRANCH" || die "Could not check out branch '$DEVELOP_BRANCH'."
-
-			if noflag nobackmerge; then
-				# Accounting for 'git describe', if a release is tagged
-				# we use the tag commit instead of the branch.
-				if noflag notag; then
-					commit="$VERSION_PREFIX$TAGNAME"
-				else
-					commit="$BASE_BRANCH"
-				fi
+		if ! git_is_branch_merged_into "$BASE_BRANCH" "$DEVELOP_BRANCH"; then
+			# Accounting for 'git describe', if a release is tagged
+			# we use the tag commit instead of the branch.
+			if noflag notag; then
+				commit="$VERSION_PREFIX$TAGNAME"
 			else
-				commit="$BRANCH"
+				commit="$BASE_BRANCH"
 			fi
 
-			git_do merge --no-ff "$commit" || die "There were merge conflicts."
-			# TODO: What do we do now?
+			# merge master to develop
+			git_do checkout "$DEVELOP_BRANCH" || die "Could not check out branch '$DEVELOP_BRANCH'."
+			git_do merge --no-ff "$commit" || die "There were merge conflicts." # TODO: What do we do now?
 		fi
 	fi
 

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -383,6 +383,7 @@ k,[no]keep            Keep branch after performing finish
 D,[no]force_delete    Force delete hotfix branch after finish
 n,[no]notag           Don't tag this hotfix
 b,[no]nobackmerge     Don't back-merge master, or tag if applicable, in develop
+r,releaseBackmerge    Back-merge to release branch if exists
 S,[no]squash          Squash hotfix during merge
 T,tagname!            Use given tag name
 "
@@ -401,25 +402,27 @@ T,tagname!            Use given tag name
 	DEFINE_boolean 'force_delete' false "force delete hotfix branch after finish" D
 	DEFINE_boolean 'notag' false "don't tag this hotfix" n
 	DEFINE_boolean 'nobackmerge' false "don't back-merge $MASTER_BRANCH, or tag if applicable, in $DEVELOP_BRANCH " b
+	DEFINE_boolean 'releasebackmerge' false "back-merge to release branch if exists" r
 	DEFINE_boolean 'squash' false "squash release during merge" S
 	DEFINE_boolean 'squash-info' false "add branch info during squash"
 	DEFINE_string  'tagname' "" "use the given tag name" T
 
 	# Override defaults with values from config
-	gitflow_override_flag_boolean   "hotfix.finish.fetch"          "fetch"
-	gitflow_override_flag_boolean   "hotfix.finish.sign"           "sign"
-	gitflow_override_flag_boolean   "hotfix.finish.push"           "push"
-	gitflow_override_flag_boolean   "hotfix.finish.keep"           "keep"
-	gitflow_override_flag_boolean   "hotfix.finish.keepremote"     "keepremote"
-	gitflow_override_flag_boolean   "hotfix.finish.keeplocal"      "keeplocal"
-	gitflow_override_flag_boolean   "hotfix.finish.force-delete"   "force_delete"
-	gitflow_override_flag_boolean   "hotfix.finish.notag"          "notag"
-	gitflow_override_flag_boolean   "hotfix.finish.nobackmerge"    "nobackmerge"
-	gitflow_override_flag_boolean   "hotfix.finish.squash"         "squash"
-	gitflow_override_flag_boolean   "hotfix.finish.squash-info"    "squash_info"
-	gitflow_override_flag_string    "hotfix.finish.signingkey"     "signingkey"
-	gitflow_override_flag_string    "hotfix.finish.message"        "message"
-	gitflow_override_flag_string    "hotfix.finish.messagefile"    "messagefile"
+	gitflow_override_flag_boolean   "hotfix.finish.fetch"             "fetch"
+	gitflow_override_flag_boolean   "hotfix.finish.sign"              "sign"
+	gitflow_override_flag_boolean   "hotfix.finish.push"              "push"
+	gitflow_override_flag_boolean   "hotfix.finish.keep"              "keep"
+	gitflow_override_flag_boolean   "hotfix.finish.keepremote"        "keepremote"
+	gitflow_override_flag_boolean   "hotfix.finish.keeplocal"         "keeplocal"
+	gitflow_override_flag_boolean   "hotfix.finish.force-delete"      "force_delete"
+	gitflow_override_flag_boolean   "hotfix.finish.notag"             "notag"
+	gitflow_override_flag_boolean   "hotfix.finish.nobackmerge"       "nobackmerge"
+	gitflow_override_flag_boolean   "hotfix.finish.releasebackmerge"  "releasebackmerge"
+	gitflow_override_flag_boolean   "hotfix.finish.squash"            "squash"
+	gitflow_override_flag_boolean   "hotfix.finish.squash-info"       "squash_info"
+  gitflow_override_flag_string    "hotfix.finish.signingkey"        "signingkey"
+	gitflow_override_flag_string    "hotfix.finish.message"           "message"
+	gitflow_override_flag_string    "hotfix.finish.messagefile"       "messagefile"
 
 	# Parse arguments
 	parse_args "$@"
@@ -564,18 +567,53 @@ T,tagname!            Use given tag name
 			else
 				commit="$BASE_BRANCH"
 			fi
-
 			# merge master to develop
 			git_do checkout "$DEVELOP_BRANCH" || die "Could not check out branch '$DEVELOP_BRANCH'."
 			git_do merge --no-ff "$commit" || die "There were merge conflicts." # TODO: What do we do now?
 		fi
 	fi
 
+	if flag releasebackmerge; then
+		_releasePrefix=$(git config --get gitflow.prefix.release)
+		release_branches=$(git_local_branches_prefixed "$_releasePrefix")
+		release_branch=
+		# Check if there is a release branch
+		if [ -n "$release_branches" ]; then
+			# Get the release branch name
+			release_branch=$(echo ${release_branches} | head -n1)
+			# Check if release branch exists on remote
+			if git_remote_branch_exists "$ORIGIN/$release_branch"; then
+				# Try to merge into release.
+				# In case a previous attempt to finish this release branch has failed,
+				# but the merge into release was successful, we skip it now
+				if ! git_is_branch_merged_into "$MERGE_BRANCH" "$release_branch"; then
+					git_do checkout "$release_branch" || die "Could not check out branch '$release_branch'."
+						# Accounting for 'git describe', if a release is tagged
+						# we use the tag commit instead of the branch.
+							if noflag notag; then
+								commit="$VERSION_PREFIX$TAGNAME"
+							else
+								commit="$BASE_BRANCH"
+							fi
+						else
+							commit="$BRANCH"
+						fi
+						git_do merge --no-ff "$commit" || die "There were merge conflicts."
+						# TODO: What do we do now?
+			else
+				echo "Remote release $release_branch not found"
+			fi
+		fi
+   	fi
+
 	run_post_hook "$VERSION_PREFIX$TAGNAME" "$ORIGIN" "$BRANCH"
 
 	if flag push; then
 		if [ "$BASE_BRANCH" = "$MASTER_BRANCH" ]; then
 			git_do push "$ORIGIN" "$DEVELOP_BRANCH" || die "Could not push branch '$DEVELOP_BRANCH' to remote '$ORIGIN'."
+		fi
+		if [ -n "$release_branch" ]; then
+		  git_do push "$ORIGIN" "$release_branch" || dir "Could not push branch '$release_branch' to remote '$ORIGIN'."
 		fi
 		git_do push "$ORIGIN" "$BASE_BRANCH" || die "Could not push branch '$BASE_BRANCH' to remote '$ORIGIN'."
 		if noflag notag; then
@@ -623,6 +661,7 @@ T,tagname!            Use given tag name
 	fi
 	if [ "$BASE_BRANCH" = "$MASTER_BRANCH" ]; then
 		[ "$commit" = "$BASE_BRANCH" ] && echo "- Master branch '$BASE_BRANCH' has been back-merged into '$DEVELOP_BRANCH'"
+		[ -n "$release_branch" ] && echo "- Hotfix tag '$VERSION_PREFIX$TAGNAME' has been back-merged into '$release_branch'"
 		[ "$commit" = "$VERSION_PREFIX$TAGNAME" ] && echo "- Hotfix tag '$VERSION_PREFIX$TAGNAME' has been back-merged into '$DEVELOP_BRANCH'"
 		[ "$commit" = "$BRANCH" ] && echo "- Hotfix branch '$BRANCH' has been merged into '$DEVELOP_BRANCH'"
 	fi


### PR DESCRIPTION
Add new option releaseBackMerge to git flow hotfix finish when there is an existing release on a remote repository we can now backmerge the hotfix onto the release branch as well as develop and master.

closes #18
closes #69 
closes nvie/gitflow#177 
closes petervanderdoes/gitflow-avh#161
