### PR TITLE
Amend release.delete.fetch to force

### DIFF
--- a/git-flow-release
+++ b/git-flow-release
@@ -1252,7 +1252,7 @@ r,[no]remote     Delete remote branch
 	DEFINE_boolean 'remote' false "delete remote branch" r
 
 	# Override defaults with values from config
-	gitflow_override_flag_boolean   "release.delete.fetch"    "fetch"
+	gitflow_override_flag_boolean   "release.delete.force"    "force"
 	gitflow_override_flag_boolean   "release.delete.remote"   "remote"
 
 	# Parse arguments


### PR DESCRIPTION
The release.delete command is mistakenly looking for the release.delete.fetch config values, but there is no fetch flag in the command.