### PR TITLE
Add ShellSpec and Bats test suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,3 +234,15 @@ in another way, however, consider donating through PayPal:
 
 [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/donate/?hosted_button_id=GU25NCHMVMT9U)
 
+
+## Running tests
+
+This project uses [ShellSpec](https://shellspec.info/) for BDD-level scenarios and [Bats](https://bats-core.readthedocs.io/) for unit tests.
+
+To execute the test suites run:
+
+```sh
+shellspec
+bats test
+```
+

--- a/spec/git_flow_init_spec.sh
+++ b/spec/git_flow_init_spec.sh
@@ -1,0 +1,25 @@
+Describe 'git flow init with defaults'
+  BeforeAll setup
+  AfterAll teardown
+
+  setup() {
+    TEST_DIR=$(mktemp -d)
+    cd "$TEST_DIR"
+    git init -q
+    /workspace/gitflow-cjs/git-flow init -d >/dev/null
+  }
+
+  teardown() {
+    rm -rf "$TEST_DIR"
+  }
+
+  It 'creates develop branch'
+    When run git rev-parse --verify develop
+    The status should be success
+  End
+
+  It 'stores branch configuration'
+    When run git config gitflow.branch.master
+    The output should eq 'master'
+  End
+End

--- a/test/git_flow_version.bats
+++ b/test/git_flow_version.bats
@@ -1,0 +1,7 @@
+#!/usr/bin/env bats
+
+@test "git flow version prints expected output" {
+  run /workspace/gitflow-cjs/git-flow version
+  [ "$status" -eq 0 ]
+  [ "$output" = "2.2.1 (CJS Edition)" ]
+}


### PR DESCRIPTION
## Summary
- add BDD tests using ShellSpec
- add TDD tests using Bats
- document how to run the test suites

## Testing
- `shellspec` *(fails: command not found)*
- `bats test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e236652dc83258b52e8cc2c786886