### PR TITLE
Add shellspec and bats tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,17 @@ the command.
 The files should be placed in .git/hooks  
 In the directory hooks you can find examples of all the hooks available.
 
+## Testing
+
+Unit level tests are written with [Bats](https://github.com/bats-core/bats-core) and behavioural tests are written with [ShellSpec](https://github.com/shellspec/shellspec). Both tools must be installed locally and available on your `PATH`.
+
+Run all tests with:
+
+```shell
+bats test/bats
+shellspec
+```
+
 
 ## Showing your appreciation
 

--- a/spec/git_flow_spec.sh
+++ b/spec/git_flow_spec.sh
@@ -1,0 +1,17 @@
+Describe 'git-flow'
+  Describe 'version command'
+    It 'prints current version' 
+      When run script ../git-flow version
+      The output should eq '2.2.1 (CJS Edition)'
+      The status should be success
+    End
+  End
+
+  Describe 'usage without arguments'
+    It 'shows help text'
+      When run script ../git-flow
+      The status should be failure
+      The output should start with 'usage: git flow'
+    End
+  End
+End

--- a/test/bats/gitflow_common.bats
+++ b/test/bats/gitflow_common.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+setup() {
+  # Source required scripts
+  source "$BATS_TEST_DIRNAME/../../gitflow-shFlags" >/dev/null
+  source "$BATS_TEST_DIRNAME/../../gitflow-common"
+}
+
+@test "check_boolean returns true for yes" {
+  run bash -c 'check_boolean yes'
+  [ "$status" -eq 0 ]
+}
+
+@test "check_boolean returns false for no" {
+  run bash -c 'check_boolean no'
+  [ "$status" -eq 1 ]
+}
+
+@test "check_boolean returns error for maybe" {
+  run bash -c 'check_boolean maybe'
+  [ "$status" -eq 2 ]
+}
+
+@test "startswith detects prefix" {
+  run bash -c 'startswith foobar foo'
+  [ "$status" -eq 0 ]
+}
+
+@test "startswith detects absence of prefix" {
+  run bash -c 'startswith foobar bar'
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary
- add a basic Bats suite covering functions in `gitflow-common`
- add a ShellSpec suite checking git-flow usage and version
- document the testing setup in the README

## Testing
- `bats test/bats` *(fails: command not found)*
- `shellspec --pattern spec/**/*_spec.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e236652dc83258b52e8cc2c786886